### PR TITLE
The command 'npm install' fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,7 @@ You need to have a JMAP server running somewhere. Currently, the most mature ser
 
 ## Setup
 
-First, clone all the Roundcube apps you'll be using and run `npm link` inside each of their directories:
-
-* `git clone https://github.com/roundcube-next/roundcube-notifications` etc
-* `cd roundcube-notifications && npm link` etc
-
-Next, change into the `roundcube-shell` directory and run `npm link <app-name>` for each Roundcube app you'll be using:
-
-* `npm link roundcube-notifications` etc
-
-Third, bring in all dependencies and set up the project:
+Bring in all dependencies and set up the project:
 
 * `bundle`
 * `npm install`

--- a/package.json
+++ b/package.json
@@ -55,8 +55,6 @@
     "ember-sinon-qunit": "1.0.0",
     "ember-suave": "1.2.2",
     "ember-truth-helpers": "1.2.0",
-    "ember-try": "0.0.8",
-    "roundcube-notifications": "latest",
-    "roundcube-mail": "latest"
+    "ember-try": "0.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "ember-sinon-qunit": "1.0.0",
     "ember-suave": "1.2.2",
     "ember-truth-helpers": "1.2.0",
-    "ember-try": "0.0.8"
+    "ember-try": "0.0.8",
+    "roundcube-notifications": "https://github.com/roundcube-next/roundcube-notifications.git",
+    "roundcube-mail": "https://github.com/roundcube-next/roundcube-mail.git"
   }
 }


### PR DESCRIPTION
The command `npm install` fails for roundcube-shell, with roundcube-mail and roundcube-notifications not being found on npmjs.org.
